### PR TITLE
Add --list flag to nusex profile subcommand.

### DIFF
--- a/nusex/cli/cli.py
+++ b/nusex/cli/cli.py
@@ -68,7 +68,7 @@ parser.add_argument(
 parser.add_argument(
     "-i",
     "--info",
-    help="show detailed information for nusex exit",
+    help="show detailed information for nusex and exit",
     action="store_true",
 )
 subparsers = parser.add_subparsers(dest="subparser")

--- a/nusex/cli/commands/profile.py
+++ b/nusex/cli/commands/profile.py
@@ -29,6 +29,7 @@
 import os
 
 from nusex import PROFILE_DIR, Profile
+from nusex.cli.commands.list import run as list_run
 from nusex.errors import AlreadyExists, DoesNotExist
 from nusex.helpers import cprint
 
@@ -45,6 +46,9 @@ def _build_profile(name):
 
 
 def run(show_current, create_new, switch, **kwargs):
+    if kwargs.get("list"):
+        return list_run(True, False)
+
     if show_current:
         return print(Profile.current().name)
 
@@ -136,5 +140,11 @@ def setup(subparsers):
         help="change the preferred license for this profile",
         metavar="LICENSE",
         default="",
+    )
+    s.add_argument(
+        "--list",
+        help="list existing profiles",
+        action="store_true",
+        default=False,
     )
     return subparsers


### PR DESCRIPTION
This pull request adds the `--list` flag to the profile subcommand, essentially an alias for `nusex list -p`. Additionally, a typo in the `--info` help message was corrected.

Closes #37 
Closes #39 
